### PR TITLE
Add passkey env var support (YGG_PASSKEY, YGG_PASSKEY_FILE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This [qBittorrent](https://github.com/qbittorrent/qBittorrent) Search Plugin use
 
 1. Download the plugin file: [yggapi.py](https://github.com/Laiteux/YggAPI-qBittorrent-Search-Plugin/blob/main/yggapi.py#L13)
 
-2. Replace the `passkey` value on [line 13](https://github.com/Laiteux/YggAPI-qBittorrent-Search-Plugin/blob/main/yggapi.py#L13) with your [YggTorrent Passkey](https://www.yggtorrent.org/user/account) _(required for downloading)_
+2. Set your [YggTorrent Passkey](https://www.yggtorrent.org/user/account) using one of the following methods _(required for downloading)_:
+
+   - **Direct Edit**: Replace the `passkey` value on [line 13](https://github.com/Laiteux/YggAPI-qBittorrent-Search-Plugin/blob/main/yggapi.py#L13) with your [YggTorrent Passkey](https://www.yggtorrent.org/user/account) _(required for downloading)_
+   - **Environment Variable**: Set `YGG_PASSKEY` to your passkey value
+   - **File**: Set `YGG_PASSKEY_FILE` to the path of a file containing your passkey
 
 Then, in qBittorrent:
 

--- a/yggapi.py
+++ b/yggapi.py
@@ -2,6 +2,7 @@
 #AUTHORS: Laiteux (matt@laiteux.dev)
 
 import json
+import os
 from datetime import datetime
 from helpers import retrieve_url
 from novaprinter import prettyPrinter
@@ -31,6 +32,20 @@ class yggapi(object):
         self.max_page = 0 # 0 = unlimited
         self.per_page = 100
         self.order_by = "seeders"
+
+        # Load passkey from environment variable or file if provided
+        env_passkey = os.getenv('YGG_PASSKEY')
+        passkey_file = os.getenv('YGG_PASSKEY_FILE')
+        if passkey_file:
+            try:
+                with open(passkey_file, 'r') as f:
+                    self.passkey = f.read().strip()
+            except (IOError, OSError):
+                # If file can't be read, fall back to env var or class default
+                if env_passkey is not None:
+                    self.passkey = env_passkey
+        elif env_passkey is not None:
+            self.passkey = env_passkey
 
     def search(self, what, cat="all"):
         category_param = ""


### PR DESCRIPTION
Hello,
First of all, thanks for this plugin!
I added this because it’s a feature I need before using the plugin on my server. I want to avoid hard-coding my passkey in the source code and committing it to Git.

This PR adds support for loading the passkey from:
- an environment variable (YGG_PASSKEY)
- a file (YGG_PASSKEY_FILE)

This makes it easier and safer to run in production or containerized environments where secrets are usually injected at runtime.
I also updated the `README` to document the different ways to configure the passkey.